### PR TITLE
add: Featured Posts (모바일) 컴포넌트 데이터 전달, UI 레이아웃 ㅈ적용

### DIFF
--- a/data/posts.json
+++ b/data/posts.json
@@ -1,0 +1,42 @@
+[
+  {
+    "title": "Markdown Extensive Example updated",
+    "description": "Learn how to write markdown",
+    "date": "2022-05-20",
+    "categories": ["markdown"],
+    "path": "Markdown-Extensive-Examples",
+    "featured": false
+  },
+  {
+    "title": "NFT Marketplace in React, Typescript & Solidity - Full Guide",
+    "description": "Learn how to use React / Next JS, Solidity, and Pinata(IPFS) to create NFT marketplace on Ethereum. All In Typescript.",
+    "date": "2022-04-25",
+    "categories": ["React", "NFT", "Solidity", "Pinata"],
+    "path": "NFT-Marketplace-in-React",
+    "featured": false
+  },
+  {
+    "title": "Rust & WebAssembly with JS (TS) - The Practical Guide",
+    "description": "Learn how to code in Rust! Compile the code to WebAssembly, prepare JS/TS frontend and finish the course by creating the practical Snake game that can run in any browser.",
+    "date": "2022-03-25",
+    "categories": ["Rust", "WebAssembly"],
+    "path": "Rust-webAssembly-with-JS",
+    "featured": false
+  },
+  {
+    "title": "Unity 2D With C# - Complete Game Dev Course",
+    "description": "Create the complete 2D survival game in Unity with C#. Learn best practices and patterns.",
+    "date": "2022-01-25",
+    "categories": ["Unity", "C#"],
+    "path": "Unity-2D-With-C#",
+    "featured": false
+  },
+  {
+    "title": "Web Development & Code 101 - Full Guide [2022]",
+    "description": "Learn programming in JS language, HTML, and CSS. Create a Web Application made in React JS. The path to the final project includes many assignments, code exercises, and challenges.",
+    "date": "2021-05-25",
+    "categories": ["HTML", "CSS", "Javascript", "NodeJS", "React"],
+    "path": "Web-Development-Full-Guide-2022",
+    "featured": false
+  }
+]

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,11 +1,12 @@
-'use client';
-
 import { PageBanner } from '@components/layout';
+import { FeaturedPosts } from '@components/layout/posts';
 
 export default function Home() {
   return (
     <section>
       <PageBanner />
+      {/* @ts-expect-error Async Server Component */}
+      <FeaturedPosts />
     </section>
   );
 }

--- a/src/components/layout/header/index.tsx
+++ b/src/components/layout/header/index.tsx
@@ -12,7 +12,7 @@ export default function PageHeader() {
   const [isOpenDropdown, setIsOpenDropdown] = useState<boolean>(false);
 
   return (
-    <header className="sticky top-0 bg-white drop-shadow-lg">
+    <header className="sticky top-0 z-10 bg-white drop-shadow-lg">
       <nav className="navbar mx-auto flex h-16 w-full max-w-7xl items-center justify-between px-8">
         <div className="logo">
           <Link href="/" className="text-2xl font-bold">
@@ -22,7 +22,7 @@ export default function PageHeader() {
             </h1>
           </Link>
         </div>
-        <ul className="links hidden gap-8 md:flex">
+        <ul className="links md:flex hidden gap-8">
           {CATEGORIES.map(({ id, link, category }) => (
             <li key={id}>
               <Link href={link}>{category}</Link>
@@ -30,7 +30,7 @@ export default function PageHeader() {
           ))}
         </ul>
         <div
-          className="toggle_btn block cursor-pointer text-2xl md:hidden"
+          className="toggle_btn md:hidden block cursor-pointer text-2xl"
           onClick={() => setIsOpenDropdown(!isOpenDropdown)}
         >
           {!isOpenDropdown ? <GoThreeBars /> : <IoMdClose />}
@@ -39,7 +39,7 @@ export default function PageHeader() {
       <div className="absolute w-full px-8">
         <ul
           className={cn(
-            'dropdown_menu flex flex-col items-center justify-center overflow-hidden rounded-md bg-slate-100 opacity-95 duration-500 ease-in-out md:hidden',
+            'dropdown_menu md:hidden flex flex-col items-center justify-center overflow-hidden rounded-md bg-slate-100 opacity-95 duration-500 ease-in-out',
             isOpenDropdown ? 'h-52' : 'h-0'
           )}
         >

--- a/src/components/layout/posts/FeaturedPosts.tsx
+++ b/src/components/layout/posts/FeaturedPosts.tsx
@@ -1,0 +1,14 @@
+import { getAllPosts } from '@service/posts';
+import React from 'react';
+import PostList from './PostList';
+
+export default async function FeaturedPosts() {
+  const posts = await getAllPosts();
+
+  return (
+    <section className="mt-6">
+      <h2 className="mb-4 text-xl font-bold text-slate-800">Featured Posts</h2>
+      <PostList posts={posts} />
+    </section>
+  );
+}

--- a/src/components/layout/posts/PostList.tsx
+++ b/src/components/layout/posts/PostList.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import Image from 'next/image';
+import { Post } from '@service/posts';
+import postImage from '../../../../public/images/main2.png';
+
+type Props = {
+  posts: Post[];
+};
+
+export default function PostList({ posts }: Props) {
+  console.log('posts >>>>>', posts);
+  return (
+    <ul className="flex flex-col gap-3">
+      {posts.map((post) => (
+        <li
+          key={post.title}
+          className="flex h-32 w-full rounded-lg bg-white px-1 shadow-lg"
+        >
+          <Image
+            src={postImage}
+            alt="post-thumbnail"
+            className="hidden h-28 w-28 rounded-lg xs:m-auto xs:block"
+          />
+          <div className="my-2 ml-1 flex w-full flex-col justify-between py-2">
+            <div className="line-clamp-1 text-xs font-medium text-rose-600">
+              {post.categories.map((category, index) => (
+                <span key={index}>#{category} </span>
+              ))}
+            </div>
+            <h3 className="line-clamp-2 text-sm font-bold">{post.title}</h3>
+            <p className="line-clamp-2 text-xs">{post.description}</p>
+          </div>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/src/components/layout/posts/index.tsx
+++ b/src/components/layout/posts/index.tsx
@@ -1,0 +1,1 @@
+export { default as FeaturedPosts } from './FeaturedPosts';

--- a/src/service/posts/index.ts
+++ b/src/service/posts/index.ts
@@ -1,0 +1,19 @@
+import { readFile } from 'fs/promises';
+import path from 'path';
+
+export type Post = {
+  title: string;
+  description: string;
+  date: Date;
+  categories: string[];
+  path: string;
+  featured: boolean;
+};
+
+export async function getAllPosts(): Promise<Post[]> {
+  const filePath = path.join(process.cwd(), 'data', 'posts.json');
+
+  return readFile(filePath, 'utf8')
+    .then<Post[]>((data) => JSON.parse(data))
+    .then((posts) => posts.sort((a, b) => (a.date > b.date ? -1 : 1)));
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -8,6 +8,9 @@ module.exports = {
         primary: '#2C3E76',
       },
     },
+    screens: {
+      xs: '320px',
+    },
   },
   plugins: [],
 };


### PR DESCRIPTION
- data/posts.json 에 임시 목업 데이터 생성
- app/service/posts.ts 에서 getAllPosts 함수, 타입 생성
- FeaturedPosts 컴포넌트에서 getAllPosts 함수를 통해 데이터를 불러다 하위 PostList 컴포넌트에 props 로 넘김
- 모바일 화면에서 보이는 Featured Posts 의 UI 마크업 적용 (현재 : 모바일만 적용한 상태)
- app/page.tsx 메인 페이지 컴포넌트에서 비동기 서버 컴포넌트 타입스크립트 오류 관련 코드 적용 (@ts-expect-error Async Server Component)
- 타입스크립트 팀에서 고쳐야 하는 이슈 핸들링 링크 : https://beta.nextjs.org/docs/configuring/typescript
  <img width="471" alt="스크린샷 2023-04-29 오후 4 45 48" src="https://user-images.githubusercontent.com/69143207/235291339-9b6bd305-23ef-40a7-b5d5-638a1b84e670.png">
