### PR TITLE
fix: Featured Posts 컴포넌트 스타일링 완료

### DIFF
--- a/src/components/layout/banner/index.tsx
+++ b/src/components/layout/banner/index.tsx
@@ -25,16 +25,16 @@ export default function PageBanner() {
   return (
     <div className="flex justify-center">
       <div className="flex w-full flex-col items-center justify-center md:w-3/5 md:items-start">
-        <h2 className="mb-4 text-2xl font-extrabold text-slate-800 md:text-3xl lg:text-5xl">
+        <h2 className="mb-4 select-none text-2xl font-extrabold text-slate-800 md:text-3xl lg:text-5xl">
           Hello, I&apos;m{' '}
           <span className="text-purple-500">
             <ReactRotatingText
-              items={['Kwangmook', 'Creative Dev', 'Selt-Confident']}
+              items={['Kwangmook', 'Creative Dev', 'Junior Dev']}
             />
           </span>
           .
         </h2>
-        <h2 className="mb-8 text-2xl font-extrabold text-slate-800 md:text-3xl lg:text-5xl">
+        <h2 className="mb-8 select-none text-2xl font-extrabold text-slate-800 md:text-3xl lg:text-5xl">
           Frontend Developer
         </h2>
         <p className="mb-7 text-lg font-bold text-slate-500 md:text-xl lg:text-2xl">

--- a/src/components/layout/posts/FeaturedPosts.tsx
+++ b/src/components/layout/posts/FeaturedPosts.tsx
@@ -7,7 +7,9 @@ export default async function FeaturedPosts() {
 
   return (
     <section className="mt-6">
-      <h2 className="mb-4 text-xl font-bold text-slate-800">Featured Posts</h2>
+      <h2 className="mb-4 text-xl font-bold text-slate-800 lg:text-2xl">
+        Featured Posts
+      </h2>
       <PostList posts={posts} />
     </section>
   );

--- a/src/components/layout/posts/PostList.tsx
+++ b/src/components/layout/posts/PostList.tsx
@@ -10,25 +10,29 @@ type Props = {
 export default function PostList({ posts }: Props) {
   console.log('posts >>>>>', posts);
   return (
-    <ul className="flex flex-col gap-3">
+    <ul className="grid grid-cols-1 gap-3 md:grid-cols-2 lg:grid-cols-3 lg:gap-6">
       {posts.map((post) => (
         <li
           key={post.title}
-          className="flex h-32 w-full rounded-lg bg-white px-1 shadow-lg"
+          className="group flex h-32 w-full cursor-pointer select-none rounded-lg bg-white px-1 shadow-lg lg:h-96 lg:flex-col lg:p-2"
         >
           <Image
             src={postImage}
             alt="post-thumbnail"
-            className="hidden h-28 w-28 rounded-lg xs:m-auto xs:block"
+            className="hidden h-28 w-28 rounded-lg object-contain group-hover:brightness-110 xs:m-auto xs:block lg:h-3/5 lg:w-full"
           />
-          <div className="my-2 ml-1 flex w-full flex-col justify-between py-2">
-            <div className="line-clamp-1 text-xs font-medium text-rose-600">
+          <div className="my-2 ml-1 flex w-full flex-col justify-start px-1 py-2 lg:m-0 lg:h-2/5 lg:px-2">
+            <div className="mb-1 line-clamp-1 text-xs font-medium text-rose-600 lg:text-sm">
               {post.categories.map((category, index) => (
                 <span key={index}>#{category} </span>
               ))}
             </div>
-            <h3 className="line-clamp-2 text-sm font-bold">{post.title}</h3>
-            <p className="line-clamp-2 text-xs">{post.description}</p>
+            <h3 className="mb-1.5 line-clamp-2 text-sm font-bold group-hover:text-rose-600 lg:text-base lg:leading-snug">
+              {post.title}
+            </h3>
+            <p className="line-clamp-2 text-xs lg:line-clamp-3 lg:text-sm lg:leading-snug">
+              {post.description}
+            </p>
           </div>
         </li>
       ))}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -10,6 +10,11 @@ module.exports = {
     },
     screens: {
       xs: '320px',
+      sm: '640px',
+      md: '768px',
+      lg: '1024px',
+      xl: '1280px',
+      '2xl': '1536px',
     },
   },
   plugins: [],


### PR DESCRIPTION
- 메인 배너 텍스트 select-none 글자 드래그 방지 적용
- 개별 post 항목 grid 레이아웃 적용
- 이미지 비율을 유지하면서 컨테이너에 맞게 채우기 위해 object-fit: contain **(object-contain)** 적용
- 부모 요소를 hover 하면 자식의 개별 요소에 hover styling 을 적용하기 위해 부모 요소에 "**group**" 클래스명을 자식 요소에 "**group-hover:-**" 선택자 사용
- 텍스트가 일정 줄 이상 늘어나는 대신 말줄임표 적용을 위해 "**line-clamp**" 적용

  <img width="1917" alt="스크린샷 2023-04-29 오후 7 38 19" src="https://user-images.githubusercontent.com/69143207/235298399-f011361b-fd9e-4970-a924-7d07312d3532.png">


