### PR TITLE
add: Post 페이지 내 상단 카테고리 필터링을 위한 Categories 컴포넌트 생성

### DIFF
--- a/src/app/posts/page.tsx
+++ b/src/app/posts/page.tsx
@@ -1,22 +1,13 @@
-import { CategorizedPosts } from '@components/layout/posts';
-
 import React from 'react';
+import Categories from '@components/categories';
+import { CategorizedPosts } from '@components/layout/posts';
 
 export default function PostsPage() {
   return (
-    <>
-      <nav className="">
-        <h2>Categories</h2>
-        <ul>
-          <li>All Posts</li>
-          <li>Dev Environment</li>
-          <li>Javascript</li>
-          <li>React</li>
-          <li>NextJS</li>
-        </ul>
-      </nav>
+    <section>
+      <Categories />
       {/* @ts-expect-error Async Server Component */}
       <CategorizedPosts />
-    </>
+    </section>
   );
 }

--- a/src/components/categories/index.tsx
+++ b/src/components/categories/index.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+import { CategoriesResponsive } from '@service/constant';
+import React from 'react';
+import Carousel from 'react-multi-carousel';
+import 'react-multi-carousel/lib/styles.css';
+
+export default function Categories() {
+  return (
+    <div className="">
+      <h2 className="mb-4 text-xl font-bold text-slate-800 lg:text-2xl">
+        Categories
+      </h2>
+      <Carousel
+        responsive={CategoriesResponsive}
+        containerClass="border border-green-500 py-4"
+        sliderClass="space-x-5"
+        itemClass="max-w-fit"
+      >
+        <span className="inline-block rounded-md border border-rose-400 bg-rose-100 px-2 py-1 font-semibold text-rose-700">
+          All Posts
+        </span>
+        <span className="inline-block rounded-md border border-orange-400 bg-orange-100 px-2 py-1 font-semibold text-orange-700">
+          Dev Environment
+        </span>
+        <span className="inline-block rounded-md border border-yellow-400 bg-yellow-100 px-2 py-1 font-semibold text-yellow-700">
+          Javascript
+        </span>
+        <span className="inline-block rounded-md border border-green-400 bg-green-100 px-2 py-1 font-semibold text-green-700">
+          Typescript
+        </span>
+        <span className="inline-block rounded-md border border-blue-400 bg-blue-100 px-2 py-1 font-semibold text-blue-700">
+          ReactJS
+        </span>
+        <span className="inline-block rounded-md border border-indigo-400 bg-indigo-100 px-2 py-1 font-semibold text-indigo-700">
+          NextJS
+        </span>
+        <span className="inline-block rounded-md border border-violet-400 bg-violet-100 px-2 py-1 font-semibold text-violet-700">
+          Refactoring
+        </span>
+      </Carousel>
+    </div>
+  );
+}

--- a/src/components/layout/posts/CarouselPosts.tsx
+++ b/src/components/layout/posts/CarouselPosts.tsx
@@ -17,8 +17,8 @@ export default function CarouselPosts({ posts }: Props) {
       responsive={PostsResponsive}
       removeArrowOnDeviceType={['mobile']}
       containerClass="rounded-md pb-8"
-      sliderClass=""
-      itemClass="md:pr-4"
+      sliderClass="md:gap-4"
+      itemClass=""
       showDots
       autoPlay
       infinite

--- a/src/service/constant.ts
+++ b/src/service/constant.ts
@@ -60,3 +60,22 @@ export const PostsResponsive = {
     items: 1,
   },
 };
+
+export const CategoriesResponsive = {
+  superLargeDesktop: {
+    breakpoint: { max: 4000, min: 3000 },
+    items: 7,
+  },
+  desktop: {
+    breakpoint: { max: 3000, min: 1024 },
+    items: 7,
+  },
+  tablet: {
+    breakpoint: { max: 1024, min: 640 },
+    items: 5,
+  },
+  mobile: {
+    breakpoint: { max: 640, min: 0 },
+    items: 3,
+  },
+};


### PR DESCRIPTION
- 카테고리 필터링을 위한 Categories 컴포넌트 생성 및 스타일링 적용, react-multi-carousel 적용
- 메인 캐루셀 적용 스타일링 변경 (gap)
<img width="1101" alt="스크린샷 2023-05-18 오후 11 58 15" src="https://github.com/seolleung2/blog-nextjs/assets/69143207/b27a4b6c-05a3-4f14-a844-2ea6c8929a54">
