### PR TITLE
fix: posts 페이지의 Categories 컴포넌트 커스텀, 스타일링

### DIFF
--- a/src/components/categories/index.tsx
+++ b/src/components/categories/index.tsx
@@ -4,6 +4,8 @@ import { CategoriesResponsive } from '@service/constant';
 import React from 'react';
 import Carousel from 'react-multi-carousel';
 import 'react-multi-carousel/lib/styles.css';
+import { BsFastForwardCircle, BsSkipBackwardCircle } from 'react-icons/bs';
+import { ArrowProps } from 'react-multi-carousel/lib/types';
 
 export default function Categories() {
   return (
@@ -13,32 +15,59 @@ export default function Categories() {
       </h2>
       <Carousel
         responsive={CategoriesResponsive}
-        containerClass="border border-green-500 py-4"
+        containerClass="p-1"
         sliderClass="space-x-5"
         itemClass="max-w-fit"
+        customLeftArrow={<CustomLeftArrow />}
+        customRightArrow={<CustomRightArrow />}
+        focusOnSelect
       >
-        <span className="inline-block rounded-md border border-rose-400 bg-rose-100 px-2 py-1 font-semibold text-rose-700">
+        <span className="inline-block cursor-pointer rounded-md border border-rose-400 bg-rose-100 px-2 py-1 font-semibold text-rose-700 transition-all duration-300 hover:origin-bottom hover:-rotate-3 hover:bg-rose-200">
           All Posts
         </span>
-        <span className="inline-block rounded-md border border-orange-400 bg-orange-100 px-2 py-1 font-semibold text-orange-700">
+        <span className="inline-block cursor-pointer rounded-md border border-orange-400 bg-orange-100 px-2 py-1 font-semibold text-orange-700 transition-all duration-300 hover:origin-bottom hover:-rotate-3 hover:bg-orange-200">
           Dev Environment
         </span>
-        <span className="inline-block rounded-md border border-yellow-400 bg-yellow-100 px-2 py-1 font-semibold text-yellow-700">
+        <span className="inline-block cursor-pointer rounded-md border border-yellow-400 bg-yellow-100 px-2 py-1 font-semibold text-yellow-700 transition-all duration-300 hover:origin-bottom hover:-rotate-3 hover:bg-yellow-200">
           Javascript
         </span>
-        <span className="inline-block rounded-md border border-green-400 bg-green-100 px-2 py-1 font-semibold text-green-700">
+        <span className="inline-block cursor-pointer rounded-md border border-green-400 bg-green-100 px-2 py-1 font-semibold text-green-700 transition-all duration-300 hover:origin-bottom hover:-rotate-3 hover:bg-green-200">
           Typescript
         </span>
-        <span className="inline-block rounded-md border border-blue-400 bg-blue-100 px-2 py-1 font-semibold text-blue-700">
+        <span className="inline-block cursor-pointer rounded-md border border-blue-400 bg-blue-100 px-2 py-1 font-semibold text-blue-700 transition-all duration-300 hover:origin-bottom hover:-rotate-3 hover:bg-blue-200">
           ReactJS
         </span>
-        <span className="inline-block rounded-md border border-indigo-400 bg-indigo-100 px-2 py-1 font-semibold text-indigo-700">
+        <span className="inline-block cursor-pointer rounded-md border border-indigo-400 bg-indigo-100 px-2 py-1 font-semibold text-indigo-700 transition-all duration-300 hover:origin-bottom hover:-rotate-3 hover:bg-indigo-200">
           NextJS
         </span>
-        <span className="inline-block rounded-md border border-violet-400 bg-violet-100 px-2 py-1 font-semibold text-violet-700">
+        <span className="inline-block cursor-pointer rounded-md border border-violet-400 bg-violet-100 px-2 py-1 font-semibold text-violet-700 transition-all duration-300 hover:origin-bottom hover:-rotate-3 hover:bg-violet-200">
           Refactoring
         </span>
       </Carousel>
     </div>
   );
 }
+
+const CustomLeftArrow = ({ onClick }: ArrowProps) => {
+  const handleClickLeftArrow = () => {
+    onClick && onClick();
+  };
+  return (
+    <BsSkipBackwardCircle
+      className="absolute left-0 cursor-pointer rounded-full border bg-slate-200 text-2xl font-bold opacity-60 transition-opacity duration-700 hover:opacity-100"
+      onClick={handleClickLeftArrow}
+    />
+  );
+};
+
+const CustomRightArrow = ({ onClick }: ArrowProps) => {
+  const handleClickRightArrow = () => {
+    onClick && onClick();
+  };
+  return (
+    <BsFastForwardCircle
+      className="absolute right-0 cursor-pointer rounded-full border bg-slate-200 text-2xl font-bold opacity-60 transition-opacity duration-700 hover:opacity-100"
+      onClick={handleClickRightArrow}
+    />
+  );
+};


### PR DESCRIPTION
- react-multi-carousel 의 화살표 커스터마이징 적용
- 화살표, 카테고리의 속성 (hover, transition, duration 등) 적용
- 세부 코드 분리, 로직 적용은 다음 커밋에 적용 예정
<img width="1011" alt="스크린샷 2023-05-19 오후 8 50 04" src="https://github.com/seolleung2/blog-nextjs/assets/69143207/6310b529-b7a6-4606-a233-8a1eb097cf6f">
