### PR TITLE
fix: 카테고리 태그 선택 시 스타일링 추가 (text decoration), PostItem 의 해시태그 회색 처리

### DIFF
--- a/src/components/categories/CarouselCategories.tsx
+++ b/src/components/categories/CarouselCategories.tsx
@@ -25,6 +25,7 @@ export default function CarouselCategories({
   return (
     <Carousel
       responsive={CategoriesResponsive}
+      removeArrowOnDeviceType={['mobile']}
       containerClass="p-1"
       sliderClass="space-x-5 items-center h-12"
       itemClass="max-w-fit"
@@ -40,13 +41,13 @@ export default function CarouselCategories({
           <span
             key={idx}
             className={cn(
-              'inline-block cursor-pointer rounded-md border px-2 py-1 font-semibold transition-all duration-300 hover:origin-bottom hover:-rotate-3',
+              'inline-block cursor-pointer rounded-md border px-2 py-1 font-semibold underline-offset-4 transition-all duration-300 hover:origin-bottom hover:-rotate-3 hover:underline',
               targetPalette?.border,
               targetPalette?.background,
               targetPalette?.color,
               targetPalette?.hover,
               currentCategory === category &&
-                'border-4 border-double font-black'
+                'border-4 border-double font-black underline decoration-double'
             )}
             onClick={handleClick.bind(null, category)}
           >

--- a/src/components/layout/posts/PostItem.tsx
+++ b/src/components/layout/posts/PostItem.tsx
@@ -25,7 +25,7 @@ export default function PostItem({
           className="hidden h-28 w-28 rounded-lg object-cover group-hover:brightness-110 xs:m-auto xs:block lg:h-1/2 lg:w-full"
         />
         <div className="my-2 ml-1 flex w-full flex-col justify-start px-1 py-2 lg:m-0 lg:h-1/2 lg:px-2">
-          <div className="mb-1 line-clamp-1 text-xs font-medium text-rose-600 lg:text-sm">
+          <div className="mb-1 line-clamp-1 text-xs font-medium text-gray-400 lg:text-sm">
             {categories.map((category, index) => (
               <span key={index}>#{category} </span>
             ))}


### PR DESCRIPTION
- 카테고리 태그 리스트 이동 화살표 (carousel arrow)는 모바일 환경에서 보여지지 않게 수정 (removeArrowOnDeviceType)
- 카테고리 태그 선택 시 스타일링 추가 (text-decoration 관련)
- PostItem 의 해시태그 부분을 text-rose 에서 회색 계열로 변경 (시선이 너무 끌림)