### PR TITLE
add: utterance 댓글 입력 컴포넌트 생성 및 적용

### DIFF
--- a/src/app/posts/[slug]/page.tsx
+++ b/src/app/posts/[slug]/page.tsx
@@ -2,12 +2,15 @@ import React from 'react';
 import { redirect } from 'next/navigation';
 import { getBlogBySlug, getBlogs } from '@service/lib/blogs';
 import MarkdownViewer from '@components/markdownViewer';
+import Utterances from '@components/utterances';
 
 type Props = {
   params: {
     slug: string;
   };
 };
+
+const utterancesRepo = 'seolleung2/blog-nextjs';
 
 // * 동적인 메타데이터 생성 generateMetadata
 export const generateMetadata = async ({ params: { slug } }: Props) => {
@@ -26,6 +29,7 @@ export default async function PostPage({ params: { slug } }: Props) {
   return (
     <section>
       <MarkdownViewer content={blog.content} />
+      <Utterances repo={utterancesRepo} path={blog.slug} />
     </section>
   );
 }

--- a/src/components/utterances/index.tsx
+++ b/src/components/utterances/index.tsx
@@ -1,0 +1,42 @@
+'use client';
+
+import React, { FunctionComponent, createRef, useEffect, useRef } from 'react';
+
+const src = 'https://utteranc.es/client.js';
+const branch = 'master';
+
+type UtteranceProps = {
+  repo: string;
+  path: string;
+};
+
+const Utterances: FunctionComponent<UtteranceProps> = ({ repo, path }) => {
+  const rootElm = createRef<HTMLDivElement>();
+  const isUtterancesLoaded = useRef<boolean>(false);
+
+  useEffect(() => {
+    if (!rootElm.current || isUtterancesLoaded.current) return;
+
+    const utterances = document.createElement('script');
+    const utterancesConfig = {
+      src,
+      repo,
+      branch,
+      theme: 'github-light',
+      label: 'comment',
+      async: true,
+      'issue-term': 'pathname',
+      crossorigin: 'anonymous',
+    } as any;
+
+    Object.keys(utterancesConfig).forEach((configKey) => {
+      utterances.setAttribute(configKey, utterancesConfig[configKey]);
+    });
+    rootElm.current.appendChild(utterances);
+    isUtterancesLoaded.current = true;
+  }, [repo, rootElm, path]);
+
+  return <div className="utterances min-w-full" ref={rootElm} />;
+};
+
+export default Utterances;


### PR DESCRIPTION
- pathname (slug) 기 비뀔 때 해당 블로그 글 항목에서 댓글 조회 및 작성 기능

<img width="875" alt="스크린샷 2023-05-23 오전 1 04 25" src="https://github.com/seolleung2/blog-nextjs/assets/69143207/ba61a2e6-5fac-41df-befb-07938cc805d4">
