### PR TITLE
fix: 마크다운 내 a 태그 모바일에서 단어 단위로 word-breaking 되는 현상 수정

### DIFF
--- a/src/components/markdownViewer/index.tsx
+++ b/src/components/markdownViewer/index.tsx
@@ -43,6 +43,16 @@ export default function MarkdownViewer({ content }: Props) {
             height={350}
           />
         ),
+        a: (data) => (
+          <a
+            className="overflow-hidden break-all"
+            href={data.href}
+            target="_blank"
+            rel="noreferrer noopener"
+          >
+            {data.href}
+          </a>
+        ),
       }}
     >
       {content}


### PR DESCRIPTION
- ReactMarkdown 컴포넌트 내 a 태그에 대한 커스텀 코드 수정
<img width="633" alt="스크린샷 2023-05-28 오후 8 35 08" src="https://github.com/seolleung2/blog-nextjs/assets/69143207/90bcc80b-43c9-4777-a1a4-8ad7034d40e4">
