### PR TITLE
fix: React Errorboundary 를 통한 커스텀 에러 (/posts/[slug] 내) 페이지 생성

### DIFF
--- a/src/app/posts/[slug]/error.tsx
+++ b/src/app/posts/[slug]/error.tsx
@@ -1,0 +1,29 @@
+'use client';
+import Button from '@components/button';
+import { useRouter } from 'next/navigation';
+
+type Props = {
+  error?: Error;
+  reset?: () => void;
+};
+
+export default function Error({ error, reset }: Props) {
+  const router = useRouter();
+
+  return (
+    <section className="mx-auto flex w-fit flex-col space-y-4">
+      <div className="">
+        <h2 className="mb-2 text-xl font-bold">Not Found</h2>
+        <p>You just hit a route that doesn&apos;t exist...😅</p>
+      </div>
+      <Button
+        className=""
+        text="Back to Posts Page"
+        handleClick={
+          // Attempt to recover by trying to re-render the segment
+          () => router.push('/posts')
+        }
+      />
+    </section>
+  );
+}

--- a/src/app/posts/[slug]/page.tsx
+++ b/src/app/posts/[slug]/page.tsx
@@ -5,6 +5,8 @@ import MarkdownViewer from '@components/markdownViewer';
 import Utterances from '@components/utterances';
 import MarkdownHeader from '@components/markdownHeader';
 import TableOfContents from '@components/toc';
+import ErrorBoundary from '@components/Error';
+import Error from './error';
 
 type Props = {
   params: {
@@ -29,14 +31,16 @@ export default async function PostPage({ params: { slug } }: Props) {
   if (!blog) redirect('/posts'); // OR Render 404 Page
 
   return (
-    <section className="relative flex flex-col xl:flex-row xl:space-x-28">
-      <article className="flex max-w-4xl grow flex-col gap-14">
-        <MarkdownHeader blog={blog} />
-        <MarkdownViewer content={blog.content} />
-        <Utterances repo={utterancesRepo} path={blog.slug} />
-      </article>
-      <TableOfContents />
-    </section>
+    <ErrorBoundary fallback={<Error />}>
+      <section className="relative flex flex-col xl:flex-row xl:space-x-28">
+        <article className="flex max-w-4xl grow flex-col gap-14">
+          <MarkdownHeader blog={blog} />
+          <MarkdownViewer content={blog.content} />
+          <Utterances repo={utterancesRepo} path={blog.slug} />
+        </article>
+        <TableOfContents />
+      </section>
+    </ErrorBoundary>
   );
 }
 

--- a/src/components/Error/index.tsx
+++ b/src/components/Error/index.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+import { Component, ErrorInfo, ReactNode } from 'react';
+
+type Props = {
+  children: ReactNode;
+  fallback: ReactNode;
+};
+type State = {
+  hasError: boolean;
+};
+
+class ErrorBoundary extends Component<Props, State> {
+  public state: State = {
+    hasError: false,
+  };
+
+  public static getDerivedStateFromError(error: Error): State {
+    return { hasError: true };
+  }
+
+  public componentDidCatch(error: Error, errorInfo: ErrorInfo) {
+    console.error('Uncaught error:', error, errorInfo);
+  }
+
+  public render() {
+    if (this.state.hasError) {
+      return this.props.fallback;
+    }
+
+    return this.props.children;
+  }
+}
+
+export default ErrorBoundary;


### PR DESCRIPTION
참조 URL : [https://nextjs.org/docs/app/building-your-application/routing/error-handling](https://nextjs.org/docs/app/building-your-application/routing/error-handling)
<img width="824" alt="스크린샷 2023-06-01 오후 10 40 35" src="https://github.com/seolleung2/blog-nextjs/assets/69143207/068da5cf-ee7a-4ea2-904a-2031dfd988be">
