### PR TITLE
add: 블로그 글 하단에서 이전 글, 다음 글로 이동이 가능하도록 코드 수정

### DIFF
--- a/src/app/posts/[slug]/page.tsx
+++ b/src/app/posts/[slug]/page.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
-import { getBlogBySlug, getBlogs } from '@service/lib/blogs';
+import { redirect } from 'next/navigation';
 import PostContent from '@components/layout/posts/PostContent';
+import ErrorBoundary from '@components/Error';
+import { getBlogBySlug, getBlogs } from '@service/lib/blogs';
 import Error from './error';
 
 type Props = {
@@ -21,9 +23,13 @@ export const generateMetadata = async ({ params: { slug } }: Props) => {
 
 export default async function PostPage({ params: { slug } }: Props) {
   const blog = await getBlogBySlug(slug);
-  if (!blog) return <Error />;
+  if (!blog) redirect('/posts');
 
-  return <PostContent blog={blog} />;
+  return (
+    <ErrorBoundary fallback={<Error />}>
+      <PostContent blog={blog} />
+    </ErrorBoundary>
+  );
 }
 
 export const generateStaticParams = async () => {

--- a/src/components/layout/posts/PostContent.tsx
+++ b/src/components/layout/posts/PostContent.tsx
@@ -3,20 +3,23 @@ import MarkdownViewer from '@components/markdownViewer';
 import Utterances from '@components/utterances';
 import MarkdownHeader from '@components/markdownHeader';
 import TableOfContents from '@components/toc';
+import BlogNavigator from '@components/navigator';
+import { utterancesRepo } from '@service/constant';
 import { Blog } from '@interfaces/Blog';
 
 type Props = {
-  blog: Blog;
+  blog: Blog & { prev: Blog | null; next: Blog | null };
 };
 
-const utterancesRepo = 'seolleung2/blog-nextjs';
-
 export default function PostContent({ blog }: Props) {
+  const { prev, next } = blog;
+
   return (
     <section className="relative flex flex-col xl:flex-row xl:space-x-28">
       <article className="flex max-w-4xl grow flex-col gap-14">
         <MarkdownHeader blog={blog} />
         <MarkdownViewer content={blog.content} />
+        <BlogNavigator prev={prev} next={next} />
         <Utterances repo={utterancesRepo} path={blog.slug} />
       </article>
       <TableOfContents />

--- a/src/components/navigator/index.tsx
+++ b/src/components/navigator/index.tsx
@@ -1,0 +1,29 @@
+'use client';
+
+import React from 'react';
+import { useRouter } from 'next/navigation';
+import { Blog } from '@interfaces/Blog';
+
+type Props = {
+  prev: Blog | null;
+  next: Blog | null;
+};
+
+export default function BlogNavigator({ prev, next }: Props) {
+  const router = useRouter();
+
+  const moveToPrevPage = () => {
+    if (prev) router.push(`/posts/${prev.slug}`);
+  };
+
+  const moveToNextPage = () => {
+    if (next) router.push(`/posts/${next.slug}`);
+  };
+
+  return (
+    <section className="flex justify-between border border-red-500">
+      <div onClick={moveToPrevPage}>prev</div>
+      <div onClick={moveToNextPage}>next</div>
+    </section>
+  );
+}

--- a/src/service/constant.ts
+++ b/src/service/constant.ts
@@ -131,3 +131,5 @@ export const ColorPaletteOfCategories = [
     hover: 'bg-violet-200',
   },
 ];
+
+export const utterancesRepo = 'seolleung2/blog-nextjs';

--- a/src/service/lib/blogs.ts
+++ b/src/service/lib/blogs.ts
@@ -27,22 +27,34 @@ const getBlogsSlugs = (): string[] => {
   );
 };
 
-const getBlog = (fileName: string): Blog | null => {
+const getBlog = (fileName: string): Blog => {
   const fullDir = getFullDirByFilename(fileName) as string;
 
-  if (fullDir) {
-    const blog = getItemInPath(fullDir) as Blog;
-    blog.slug = fileName.replace(/\.md$/, '');
+  const blog = getItemInPath(fullDir) as Blog;
+  blog.slug = fileName.replace(/\.md$/, '');
 
-    return blog;
-  }
-
-  return null;
+  return blog;
 };
 
 const getBlogBySlug = (slug: string) => {
+  const allBlogs = getBlogs();
+
+  const blog = allBlogs.find((blog) => blog.slug === slug);
+
+  if (!blog)
+    throw new Error(`${slug}에 해당하는 블로그 내용을 찾을 수 없습니다.`);
+
   const fileName = slug + '.md';
-  return getBlog(fileName);
+
+  const index = allBlogs.indexOf(blog);
+  const next = index > 0 ? allBlogs[index - 1] : null;
+  const prev = index < allBlogs.length - 1 ? allBlogs[index + 1] : null;
+
+  return {
+    ...getBlog(fileName),
+    next,
+    prev,
+  };
 };
 
 const getBlogs = (): Blog[] => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -30,5 +30,5 @@
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", ".next"]
 }


### PR DESCRIPTION
- blogs.ts 에서 /posts/[slug] 접근 시 이전 항목과 다음 항목에 대한 정보도 전달하도록 코드 개선
- 블로그 글 하단에서 이전 글, 다음 글 이동 되도록 코드 수정
- CSS 작업은 진행 예정