### PR TITLE
fix: 블로그 하단 BlogNavigator UI 수정작업

### DIFF
--- a/src/components/navigator/index.tsx
+++ b/src/components/navigator/index.tsx
@@ -15,7 +15,7 @@ export default function BlogNavigator({ prev, next }: Props) {
   const router = useRouter();
 
   const moveToPrevPage = () => {
-    router.push(`/posts/${prev.slug}`);
+    if (prev) router.push(`/posts/${prev.slug}`);
   };
 
   const moveToNextPage = () => {

--- a/src/components/navigator/index.tsx
+++ b/src/components/navigator/index.tsx
@@ -2,6 +2,8 @@
 
 import React from 'react';
 import { useRouter } from 'next/navigation';
+import Image from 'next/image';
+import { MdSkipPrevious, MdSkipNext } from 'react-icons/md';
 import { Blog } from '@interfaces/Blog';
 
 type Props = {
@@ -13,7 +15,7 @@ export default function BlogNavigator({ prev, next }: Props) {
   const router = useRouter();
 
   const moveToPrevPage = () => {
-    if (prev) router.push(`/posts/${prev.slug}`);
+    router.push(`/posts/${prev.slug}`);
   };
 
   const moveToNextPage = () => {
@@ -21,9 +23,51 @@ export default function BlogNavigator({ prev, next }: Props) {
   };
 
   return (
-    <section className="flex justify-between border border-red-500">
-      <div onClick={moveToPrevPage}>prev</div>
-      <div onClick={moveToNextPage}>next</div>
+    <section className="flex space-x-4">
+      {prev && (
+        <div
+          className="group relative flex h-16 w-1/2 cursor-pointer items-center justify-start space-x-2 rounded-md bg-slate-200 p-3 font-medium shadow-lg hover:bg-purple-500 hover:text-white md:h-28 md:bg-transparent md:font-bold md:text-white md:hover:bg-transparent"
+          onClick={moveToPrevPage}
+        >
+          <MdSkipPrevious className="block text-xl md:w-1/6 md:text-3xl" />
+          <span className="md:hidden">이전 블로그로</span>
+          <div className=" line-clamp-2 hidden flex-col items-start space-y-2 md:flex">
+            <span className="w-fit rounded-lg bg-slate-200 px-2 py-0.5 text-black">
+              이전글
+            </span>
+            <p className="h-12">{prev?.title || ''}</p>
+          </div>
+          <Image
+            src={prev?.coverImage || '/images/default-cover.jpg'}
+            alt="post-thumbnail"
+            width={120}
+            height={80}
+            className="absolute right-0 -z-10 hidden h-28 w-full rounded-md object-cover brightness-50 group-hover:brightness-75 md:block"
+          />
+        </div>
+      )}
+      {next && (
+        <div
+          className="group relative flex h-16 w-1/2 cursor-pointer items-center justify-end space-x-2 rounded-md bg-slate-200 p-3 font-medium shadow-lg hover:bg-purple-500 hover:text-white md:h-28 md:bg-transparent md:font-bold md:text-white md:hover:bg-transparent"
+          onClick={moveToNextPage}
+        >
+          <span className="md:hidden">다음 블로그로</span>
+          <div className=" line-clamp-2 hidden flex-col items-end space-y-2 md:flex">
+            <span className="w-fit rounded-lg bg-slate-200 px-2 py-0.5 text-black">
+              다음글
+            </span>
+            <p className="h-12">{next?.title || ''}</p>
+          </div>
+          <Image
+            src={next?.coverImage || '/images/default-cover.jpg'}
+            alt="post-thumbnail"
+            width={120}
+            height={80}
+            className="absolute right-0 -z-10 hidden h-28 w-full rounded-md object-cover brightness-50 group-hover:brightness-75 md:block"
+          />
+          <MdSkipNext className="block text-xl md:w-1/6 md:text-3xl" />
+        </div>
+      )}
     </section>
   );
 }


### PR DESCRIPTION
- 이전글, 다음글에 대한 모바일, 태블릿 이상의 화면에서 보여질 BlogNavigator UI 수정
<img width="1915" alt="스크린샷 2023-06-04 오후 3 54 22" src="https://github.com/seolleung2/blog-nextjs/assets/69143207/50b5b5a8-901c-4068-a6d4-21782f9761f0">
